### PR TITLE
Extract ToneGenerator construction out of Sound via dependency injection

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,5 +1,6 @@
 import { CPU } from "./utils/cpu";
 import { ROM } from "./utils/rom";
+import { ToneGenerator } from "./utils/tone-generator";
 
 import { readFileSync } from "@zos/fs";
 
@@ -20,7 +21,8 @@ App({
     this.globalData.rom = new ROM(data);
 
     const clock = 1600000;
-    this.globalData.cpu = new CPU(this.globalData.rom, clock);
+    const toneGenerator = new ToneGenerator();
+    this.globalData.cpu = new CPU(this.globalData.rom, clock, toneGenerator);
 
     this.globalData.updateInterval = setInterval(() => {
       //const startTime = new Date();

--- a/utils/cpu.js
+++ b/utils/cpu.js
@@ -206,9 +206,9 @@ const mask = {
 
 // E0C6200
 export class CPU {
-  constructor(rom, clock) {
+  constructor(rom, clock, toneGenerator) {
     this._ROM = rom;
-    this._sound = new Sound(OSC1_CLOCK);
+    this._sound = new Sound(OSC1_CLOCK, toneGenerator);
 
     this._port_pullup = mask.port_pullup;
 

--- a/utils/sound.js
+++ b/utils/sound.js
@@ -1,5 +1,3 @@
-import { ToneGenerator } from "./tone-generator";
-
 const BUZZER_FREQ_DIV = [8, 10, 12, 14, 16, 20, 24, 28];
 // const ENVELOP_STEP_DIV = [16, 20, 24, 28, 16, 20, 24, 28]; // Unused
 
@@ -9,7 +7,7 @@ const ENVELOPE_CYCLE_DIV = [16 * SOUND_CLOCK_DIV, 32 * SOUND_CLOCK_DIV];
 
 // Sound for E0C6200 CPU
 export class Sound {
-  constructor(clock) {
+  constructor(clock, toneGenerator) {
     this._system_clock = clock;
     this._one_shot_counter = 0;
     this._buzzer_freq = clock / BUZZER_FREQ_DIV[0];
@@ -20,7 +18,7 @@ export class Sound {
     this._sound_on = false;
     this._cycle_counter = 0;
 
-    this._tone_generator = new ToneGenerator();
+    this._tone_generator = toneGenerator;
   }
 
   clock() {


### PR DESCRIPTION
Sound and CPU no longer import or instantiate ToneGenerator directly.
ToneGenerator is now constructed in app.js (the ZeppOS entry point) and
threaded down through CPU -> Sound as a constructor parameter. This makes
both Sound and CPU testable in non-ZeppOS environments (e.g. Node.js)
by allowing a mock toneGenerator to be injected.