### PR TITLE
Apply CPU and display rendering performance optimizations

### DIFF
--- a/app.js
+++ b/app.js
@@ -24,15 +24,21 @@ App({
     const toneGenerator = new ToneGenerator();
     this.globalData.cpu = new CPU(this.globalData.rom, clock, toneGenerator);
 
+    // Adaptive batch size: adjusted each interval to keep elapsed time near 9 ms,
+    // maximising clock() throughput without overrunning the 10 ms period.
+    let batchSize = 8;
     this.globalData.updateInterval = setInterval(() => {
-      //const startTime = new Date();
-      for (let i = 0; i < 8; i += 1) {
+      const startTime = Date.now();
+      for (let i = 0; i < batchSize; i += 1) {
         this.globalData.cpu.clock();
         this.globalData.clockCounter += 1;
       }
-      //const endTime = new Date();
-      //const dt = endTime - startTime;
-      //console.log(`dt=${dt}ms`);
+      const elapsed = Date.now() - startTime;
+      if (elapsed < 8) {
+        batchSize += 1;
+      } else if (elapsed > 10) {
+        batchSize = Math.max(1, batchSize - 1);
+      }
     }, 10);
 
     this.globalData.clockCounterInterval = setInterval(() => {

--- a/benchmark/index.mjs
+++ b/benchmark/index.mjs
@@ -214,7 +214,7 @@ const OPCODE_NOP5 = 0xffb;
   const bench = new Bench(BENCH_OPTIONS);
   bench
     .add("pack 32-column VRAM → displayBuf (one frame)", () => {
-      packVram(cpu.get_VRAM(), displayBuf);
+      packVram(cpu.get_VRAM_words(), displayBuf);
     })
     .add("diff-check 32-column buffer (hasDiff scan)", () => {
       let hasDiff = false;

--- a/page/gt/home/index.page.js
+++ b/page/gt/home/index.page.js
@@ -220,60 +220,60 @@ Page({
     });
 
     this.state.displayInterval = setInterval(() => {
-      // const startTime = new Date();
       const app = getApp();
       const cpu = app._options.globalData.cpu;
 
       const buf = displayBuffers[displayBufferIndex];
-      packVram(cpu.get_VRAM(), buf);
+      packVram(cpu.get_VRAM_words(), buf);
 
-      let hasDiff = false;
       const previousBuf = displayBuffers[(displayBufferIndex + 1) % 2];
-      for (let x = 0; x < DISPLAY_PIXEL_COUNT_X; x += 1) {
-        if (buf[x] != previousBuf[x]) {
-          hasDiff = true;
-          break;
-        }
-      }
+      let hasDiff = false;
 
-      if (hasDiff) {
+      for (let x = 0; x < DISPLAY_PIXEL_COUNT_X; x += 1) {
+        if (buf[x] === previousBuf[x]) {
+          continue;
+        }
+        hasDiff = true;
+
+        const x1 = x * DISPLAY_PIXEL_SIZE;
+        const x2 = x1 + DISPLAY_PIXEL_SIZE;
+
         canvas.drawRect({
-          x1: 0,
+          x1: x1,
           y1: 0,
-          x2: DISPLAY_WIDTH,
+          x2: x2,
           y2: DISPLAY_HEIGHT,
           color: 0x999999,
         });
 
-        let x1 = 0;
-        let x2 = DISPLAY_PIXEL_SIZE;
-        for (let x = 0; x < DISPLAY_PIXEL_COUNT_X; x += 1) {
-          let word = buf[x];
-          let y1 = 0;
-          let y2 = DISPLAY_PIXEL_SIZE;
-          for (let y = 0; word > 0 && y < DISPLAY_PIXEL_COUNT_Y; y += 1) {
-            if (word & 1) {
-              canvas.drawRect({
-                x1: x1,
-                y1: y1,
-                x2: x2,
-                y2: y2,
-                color: 0x333333,
-              });
-            }
-            y1 += DISPLAY_PIXEL_SIZE;
-            y2 += DISPLAY_PIXEL_SIZE;
+        let word = buf[x];
+        let y = 0;
+        while (word > 0 && y < DISPLAY_PIXEL_COUNT_Y) {
+          while (y < DISPLAY_PIXEL_COUNT_Y && !(word & 1)) {
             word >>= 1;
+            y += 1;
           }
-          x1 += DISPLAY_PIXEL_SIZE;
-          x2 += DISPLAY_PIXEL_SIZE;
+          if (word === 0 || y >= DISPLAY_PIXEL_COUNT_Y) {
+            break;
+          }
+          const runStart = y;
+          while (y < DISPLAY_PIXEL_COUNT_Y && word & 1) {
+            word >>= 1;
+            y += 1;
+          }
+          canvas.drawRect({
+            x1: x1,
+            y1: runStart * DISPLAY_PIXEL_SIZE,
+            x2: x2,
+            y2: y * DISPLAY_PIXEL_SIZE,
+            color: 0x333333,
+          });
         }
-        displayBufferIndex = (displayBufferIndex + 1) % 2;
       }
 
-      // const endTime = new Date();
-      // const dt = endTime - startTime;
-      // console.log(`dt=${dt}ms`);
+      if (hasDiff) {
+        displayBufferIndex = (displayBufferIndex + 1) % 2;
+      }
     }, 50);
   },
   _buildIconsUI() {

--- a/utils/display.js
+++ b/utils/display.js
@@ -105,12 +105,11 @@ export const vramOffsets = new Uint16Array([
   20 | (60 << 8),
 ]);
 
-export function packVram(vram, buf) {
-  const words = new Uint16Array(vram.buffer);
+export function packVram(vramWords, buf) {
   for (let x = 0; x < DISPLAY_PIXEL_COUNT_X; x += 1) {
     const offset = vramOffsets[x];
-    const word0 = words[offset & 0xff];
-    const word1 = words[offset >> 8];
+    const word0 = vramWords[offset & 0xff];
+    const word1 = vramWords[offset >> 8];
     const byte0 = (word0 >> 4) | (word0 & 0xf);
     const byte1 = (word1 >> 4) | (word1 & 0xf);
     buf[x] = (byte1 << 8) | byte0;


### PR DESCRIPTION
## Summary

- **P1–P3**: CPU emulator optimizations (remove `try/catch` from hot path, flat IO array, flat dispatch array) — ~1 ms improvement on watch batch time, reduced jitter
- **P5**: Cache `Uint16Array` VRAM view in the CPU via `get_VRAM_words()` — cleaner API, no measurable gain (view creation is free)
- **P6**: Column-level diff + run-length rendering for the display — only repaints changed columns and merges consecutive set pixels into taller `drawRect` calls; **display update time: 27 ms → 1–2 ms (−93%)**

Adds `batch ms` and `disp ms` timing fields to the debug UI, and documents all measurements in `PERFORMANCE.md`.