### PR TITLE
Replace instruction counter with batch size display

### DIFF
--- a/app.js
+++ b/app.js
@@ -12,6 +12,7 @@ App({
     clockCounterInterval: undefined,
     clockCounter: 0,
     clocksPerSecond: 0,
+    batchSize: 0,
   },
   onCreate(/*options*/) {
     console.log("app on create invoke");
@@ -39,6 +40,7 @@ App({
       } else if (elapsed > 20) {
         batchSize = Math.max(1, batchSize - 1);
       }
+      this.globalData.batchSize = batchSize;
     }, 20);
 
     let lastReset = Date.now();

--- a/page/gt/home/index.page.js
+++ b/page/gt/home/index.page.js
@@ -76,8 +76,8 @@ Page({
     clearInterval(this.state.stateInterval);
   },
   _buildDebugUI() {
-    const insText = createWidget(widget.TEXT, {
-      text: "#ins 0",
+    const batchText = createWidget(widget.TEXT, {
+      text: "batch 0",
       x: 140,
       y: 30,
       w: 100,
@@ -166,14 +166,17 @@ Page({
       text_size: 15,
     });
 
-    this.state.sateInterval = setInterval(() => {
+    this.state.stateInterval = setInterval(() => {
       const app = getApp();
       const cpuModule = app._options.globalData.cpu;
       clockMS.setProperty(
         prop.TEXT,
         `${(1000 / app._options.globalData.clocksPerSecond).toFixed(2)}ms`,
       );
-      insText.setProperty(prop.TEXT, `#ins ${cpuModule.istr_counter()}`);
+      batchText.setProperty(
+        prop.TEXT,
+        `batch ${app._options.globalData.batchSize}`,
+      );
       pcText.setProperty(
         prop.TEXT,
         `PC 0x${cpuModule.pc().toString(16).padStart(4, "0")}`,


### PR DESCRIPTION
## Summary

- Replaces the `#ins` instruction counter in the debug UI with the current adaptive batch size
- Adds `batchSize` to `globalData` so the page can read it via `getApp()`
- Fixes a pre-existing typo (`sateInterval` → `stateInterval`) that prevented the debug panel interval from being cleared on page destroy